### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 # OkHttpClient integration with Ribbon
 
-This module supplies integration with Square's [`OkHttpClient`](http://square.github.io/okhttp/) and Netflix [Ribbon](https://github.com/Netflix/ribbon) via [Spring Cloud Netflix](https://github.com/spring-cloud/spring-cloud-netflix).
+This module supplies integration with Square's [`OkHttpClient`](https://square.github.io/okhttp/) and Netflix [Ribbon](https://github.com/Netflix/ribbon) via [Spring Cloud Netflix](https://github.com/spring-cloud/spring-cloud-netflix).
 
 An application interceptor is added to the `OkHttpClient` created via autoconfiguration which resolves the scheme, host and port from ribbon and rewrites the url.
 
-By supporting `OkHttpClient`, it enables Square's [Retrofit](http://square.github.io/retrofit/) to use ribbon as well.
+By supporting `OkHttpClient`, it enables Square's [Retrofit](https://square.github.io/retrofit/) to use ribbon as well.
 
 See [`OkHttpRibbonInterceptorTests`](https://github.com/spencergibb/okhttp-ribbon/blob/master/src/test/java/org/springframework/cloud/square/okhttp/OkHttpRibbonInterceptorTests.java) for samples.

--- a/spring-cloud-square-retrofit/src/test/java/org/springframework/cloud/retrofit/support/RetrofitRibbonNoAnnotationTests.java
+++ b/spring-cloud-square-retrofit/src/test/java/org/springframework/cloud/retrofit/support/RetrofitRibbonNoAnnotationTests.java
@@ -93,7 +93,7 @@ public class RetrofitRibbonNoAnnotationTests {
 			HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor();
 			loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
 
-			return new Retrofit.Builder().baseUrl("http://localapp")
+			return new Retrofit.Builder().baseUrl("https://localapp")
 					.client(new OkHttpClient.Builder()
 							.addInterceptor(loggingInterceptor)
 							.addInterceptor(ribbonInterceptor)


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://localapp (UnknownHostException) with 1 occurrences migrated to:  
  https://localapp ([https](https://localapp) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://square.github.io/okhttp/ with 1 occurrences migrated to:  
  https://square.github.io/okhttp/ ([https](https://square.github.io/okhttp/) result 200).
* [ ] http://square.github.io/retrofit/ with 1 occurrences migrated to:  
  https://square.github.io/retrofit/ ([https](https://square.github.io/retrofit/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 2 occurrences
* http://testapp with 1 occurrences