### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-square-okhttp/src/main/java/org/springframework/cloud/square/okhttp/DependsOnLoadBalancedClient.java
+++ b/spring-cloud-square-okhttp/src/main/java/org/springframework/cloud/square/okhttp/DependsOnLoadBalancedClient.java
@@ -6,7 +6,7 @@ package org.springframework.cloud.square.okhttp;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-square-retrofit/src/main/java/org/springframework/cloud/retrofit/DefaultRetrofitClientConfiguration.java
+++ b/spring-cloud-square-retrofit/src/main/java/org/springframework/cloud/retrofit/DefaultRetrofitClientConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-square-retrofit/src/main/java/org/springframework/cloud/retrofit/EnableRetrofitClients.java
+++ b/spring-cloud-square-retrofit/src/main/java/org/springframework/cloud/retrofit/EnableRetrofitClients.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-square-retrofit/src/main/java/org/springframework/cloud/retrofit/RetrofitAutoConfiguration.java
+++ b/spring-cloud-square-retrofit/src/main/java/org/springframework/cloud/retrofit/RetrofitAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-square-retrofit/src/main/java/org/springframework/cloud/retrofit/RetrofitClient.java
+++ b/spring-cloud-square-retrofit/src/main/java/org/springframework/cloud/retrofit/RetrofitClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-square-retrofit/src/main/java/org/springframework/cloud/retrofit/RetrofitClientFactoryBean.java
+++ b/spring-cloud-square-retrofit/src/main/java/org/springframework/cloud/retrofit/RetrofitClientFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-square-retrofit/src/main/java/org/springframework/cloud/retrofit/RetrofitClientSpecification.java
+++ b/spring-cloud-square-retrofit/src/main/java/org/springframework/cloud/retrofit/RetrofitClientSpecification.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-square-retrofit/src/main/java/org/springframework/cloud/retrofit/RetrofitClientsRegistrar.java
+++ b/spring-cloud-square-retrofit/src/main/java/org/springframework/cloud/retrofit/RetrofitClientsRegistrar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-square-retrofit/src/main/java/org/springframework/cloud/retrofit/RetrofitContext.java
+++ b/spring-cloud-square-retrofit/src/main/java/org/springframework/cloud/retrofit/RetrofitContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-square-retrofit/src/test/java/org/springframework/cloud/retrofit/RetrofitClientReactorTests.java
+++ b/spring-cloud-square-retrofit/src/test/java/org/springframework/cloud/retrofit/RetrofitClientReactorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-square-retrofit/src/test/java/org/springframework/cloud/retrofit/RetrofitClientRibbonTests.java
+++ b/spring-cloud-square-retrofit/src/test/java/org/springframework/cloud/retrofit/RetrofitClientRibbonTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-square-retrofit/src/test/java/org/springframework/cloud/retrofit/RetrofitClientUrlTests.java
+++ b/spring-cloud-square-retrofit/src/test/java/org/springframework/cloud/retrofit/RetrofitClientUrlTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-square-retrofit/src/test/java/org/springframework/cloud/retrofit/support/RetrofitNoAnnotationTests.java
+++ b/spring-cloud-square-retrofit/src/test/java/org/springframework/cloud/retrofit/support/RetrofitNoAnnotationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-square-retrofit/src/test/java/org/springframework/cloud/retrofit/support/RetrofitRibbonNoAnnotationTests.java
+++ b/spring-cloud-square-retrofit/src/test/java/org/springframework/cloud/retrofit/support/RetrofitRibbonNoAnnotationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 15 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).