### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 # OkHttpClient integration with Ribbon
 
-This module supplies integration with Square's [`OkHttpClient`](http://square.github.io/okhttp/) and Netflix [Ribbon](https://github.com/Netflix/ribbon) via [Spring Cloud Netflix](https://github.com/spring-cloud/spring-cloud-netflix).
+This module supplies integration with Square's [`OkHttpClient`](https://square.github.io/okhttp/) and Netflix [Ribbon](https://github.com/Netflix/ribbon) via [Spring Cloud Netflix](https://github.com/spring-cloud/spring-cloud-netflix).
 
 An application interceptor is added to the `OkHttpClient` created via autoconfiguration which resolves the scheme, host and port from ribbon and rewrites the url.
 
-By supporting `OkHttpClient`, it enables Square's [Retrofit](http://square.github.io/retrofit/) to use ribbon as well.
+By supporting `OkHttpClient`, it enables Square's [Retrofit](https://square.github.io/retrofit/) to use ribbon as well.
 
 See [`OkHttpRibbonInterceptorTests`](https://github.com/spencergibb/okhttp-ribbon/blob/master/src/test/java/org/springframework/cloud/square/okhttp/OkHttpRibbonInterceptorTests.java) for samples.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://square.github.io/okhttp/ with 1 occurrences migrated to:  
  https://square.github.io/okhttp/ ([https](https://square.github.io/okhttp/) result 200).
* [ ] http://square.github.io/retrofit/ with 1 occurrences migrated to:  
  https://square.github.io/retrofit/ ([https](https://square.github.io/retrofit/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localapp with 1 occurrences
* http://localhost with 2 occurrences
* http://testapp with 1 occurrences